### PR TITLE
Issue 440 popular search item duplicates

### DIFF
--- a/tests/regression-sprint-1.coffee
+++ b/tests/regression-sprint-1.coffee
@@ -306,7 +306,7 @@ describe '| regression-sprint-1 |', ->                                          
       page.open '/user/main.html', (html,$)->
         $('input').attr().assert_Is {"type":"text","id":"search-input","name":"text","class":"form-control"}
         code = "document.querySelector('input').value='#{searchText}';
-                      document.querySelector('button').click()"
+                document.querySelector('button').click()"
         page.eval code, ->
           page.wait_For_Complete (html, $)->
             page.chrome.url (url)->

--- a/tests/regression-sprint-1.coffee
+++ b/tests/regression-sprint-1.coffee
@@ -316,3 +316,4 @@ describe '| regression-sprint-1 |', ->                                          
               values.assert_Contains("xss")
               values.assert_Is_Equal_To(values.unique())
               done()
+              

--- a/tests/regression-sprint-1.coffee
+++ b/tests/regression-sprint-1.coffee
@@ -299,3 +299,20 @@ describe '| regression-sprint-1 |', ->                                          
       $('ul').html().assert_Contains('Sign Up')
       $('ul').html().assert_Contains('Login')
       done()
+
+  it 'Issue 440 - Check for no duplicates in Popular Search Terms', (done) ->
+    jade.login_As_User ()->
+      page.open '/user/main.html', (html,$)->
+        $('input').attr().assert_Is {"type":"text","id":"search-input","name":"text","class":"form-control"}
+        page.open "/search?text=xss", (html,$)->
+          page.chrome.url (url)->
+            url.assert_Contains '/search?text=xss'
+            $('input').attr('value').assert_Is('xss')
+            page.open '/user/main.html', (html,$)->
+              $('input').attr().assert_Is {"type":"text","id":"search-input","name":"text","class":"form-control"}
+              values = []
+              for td in $('#popular-Search-Terms .nav td')
+                values.push($(td).text())
+              values.assert_Contains("xss")
+              values.assert_Is_Equal_To(values.unique())
+              done()


### PR DESCRIPTION
``` Coffeescript
  it 'Issue 440 - Check for no duplicates in Popular Search Terms', (done) ->
    jade.login_As_User ()->
      page.open '/user/main.html', (html,$)->
        $('input').attr().assert_Is {"type":"text","id":"search-input","name":"text","class":"form-control"}
        page.open "/search?text=xss", (html,$)->
          page.chrome.url (url)->
            url.assert_Contains '/search?text=xss'
            $('input').attr('value').assert_Is('xss')
            page.open '/user/main.html', (html,$)->
              $('input').attr().assert_Is {"type":"text","id":"search-input","name":"text","class":"form-control"}
              values = []
              for td in $('#popular-Search-Terms .nav td')
                values.push($(td).text())
              values.assert_Contains("xss")
              values.assert_Is_Equal_To(values.unique())
              done()
```
