### PR TITLE
Fix for Webstorm regex error TeamMentor/TM_4_0_Design/701

### DIFF
--- a/tests/jade/page-article.test.coffee
+++ b/tests/jade/page-article.test.coffee
@@ -31,7 +31,7 @@ describe '| jade | page-article |',->
       article_Html.attr().href.assert_Is "/article/#{id}/#{article_Data.title.replace(/\ /g,"-")}"
       done()
 
-  describe '/article/:key',->
+  describe.only '/article/:key',->
 
     article = null
 
@@ -60,7 +60,9 @@ describe '| jade | page-article |',->
       check_Article_Contents article.title , '#title', article.title , done
 
     it 'by dashed-title', (done)->
-      dashed_Title = article.title.replace(/ /g,'-')
+      log "\n" + article.title
+      dashed_Title = article.title.replace(/\s/g,'-')
+      log "\n" + dashed_Title
       check_Article_Contents dashed_Title  , '#title', article.title , done
 
     it 'by id and title', (done)->

--- a/tests/jade/page-article.test.coffee
+++ b/tests/jade/page-article.test.coffee
@@ -31,7 +31,7 @@ describe '| jade | page-article |',->
       article_Html.attr().href.assert_Is "/article/#{id}/#{article_Data.title.replace(/\ /g,"-")}"
       done()
 
-  describe.only '/article/:key',->
+  describe '/article/:key',->
 
     article = null
 
@@ -60,9 +60,7 @@ describe '| jade | page-article |',->
       check_Article_Contents article.title , '#title', article.title , done
 
     it 'by dashed-title', (done)->
-      log "\n" + article.title
       dashed_Title = article.title.replace(/\s/g,'-')
-      log "\n" + dashed_Title
       check_Article_Contents dashed_Title  , '#title', article.title , done
 
     it 'by id and title', (done)->


### PR DESCRIPTION
Webstorm uses the Java-based regex engine which indicates whitespace by the \s pattern:
https://www.jetbrains.com/webstorm/help/regular-expression-syntax-reference.html
http://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html

As far as I can tell, javascript v8 engine also uses similar regex patterns, including the \s pattern to indicate whitespace:
http://www.w3schools.com/jsref/jsref_obj_regexp.asp
